### PR TITLE
Upgrade to JUnit 5.2 and bump other library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,21 +17,21 @@
         <logback.version>1.2.3</logback.version>
 
         <!-- Test dependencies -->
-        <junit.jupiter.version>5.1.1</junit.jupiter.version>
-        <junit.platform.version>1.1.1</junit.platform.version>
+        <junit.jupiter.version>5.2.0</junit.jupiter.version>
+        <junit.platform.version>1.2.0</junit.platform.version>
         <selenium-server.version>3.11.0</selenium-server.version>
-        <mockito-core.version>2.16.0</mockito-core.version>
+        <mockito-core.version>2.18.3</mockito-core.version>
         <hamcrest.version>1.3</hamcrest.version>
         <awaitility.version>3.1.0</awaitility.version>
 
         <!-- Plugins -->
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-        <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>2.21.0</maven-surefire-plugin.version>
         <maven-asciidoctor-plugin.version>1.5.5</maven-asciidoctor-plugin.version>
         <asciidoctorj-pdf.version>1.5.0-alpha.16</asciidoctorj-pdf.version>
         <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.1</jacoco-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
 


### PR DESCRIPTION
### Test dependencies
- junit.jupiter.version  = 5.2.0
- junit.platform.version = 1.2.0
- mockito-core.version   = 2.18.3

### Plugins
- maven-surefire-plugin.version = 2.21.0
- jacoco-maven-plugin.version   = 0.8.1