### PR TITLE
Fix typos in docs

### DIFF
--- a/src/doc/asciidoc/advanced.adoc
+++ b/src/doc/asciidoc/advanced.adoc
@@ -144,7 +144,7 @@ image::jenkins-attachements-test.png[scaledwidth=100%]
 We can watch the recording simply clicking in the attached MP4 files.
 
 [.thumb]
-.Example of test execution through Jenkins with attachements
+.Example of test execution through Jenkins with attachments
 image::jenkins-attachements-test-mp4.png[scaledwidth=100%]
 
 Test template are also compatible with this feature. For instance, consider the following test

--- a/src/doc/asciidoc/configuration.adoc
+++ b/src/doc/asciidoc/configuration.adoc
@@ -25,7 +25,7 @@ Default configuration parameters for _Selenium-Jupiter_ are set in the https://g
 |`sel.jup.default.browser.fallback.version` | Fallback version list for generic driver |`latest,latest,latest,latest,latest`
 |`sel.jup.browser.list.from.docker.hub` | Update Docker images list from Docker Hub |`true`
 |`sel.jup.browser.session.timeout.duration` | Session timeout for Docker browsers (in Golang duration format)|`1m0s`
-|`sel.jup.selenoid.image` | Selenoid (Golang Selenium Hub) Docker iamage |`aerokube/selenoid:1.6.0`
+|`sel.jup.selenoid.image` | Selenoid (Golang Selenium Hub) Docker image |`aerokube/selenoid:1.6.0`
 |`sel.jup.selenoid.port` | Selenoid port |`4444`
 |`sel.jup.selenoid.vnc.password` | VNC password for Selenoid sessions |`selenoid`
 |`sel.jup.novnc.image` | noVNC Docker image |`psharkey/novnc:3.3-t6`
@@ -50,7 +50,7 @@ Default configuration parameters for _Selenium-Jupiter_ are set in the https://g
 |`sel.jup.opera.first.version` | First version of Docker Opera (used when `sel.jup.browser.list.from.docker.hub =false`) |`33.0`
 |`sel.jup.opera.latest.version` | Latest version of Docker Opera (used when `sel.jup.browser.list.from.docker.hub =false`) |`51.0`
 |`sel.jup.opera.path` | Path for Hub when using Opera in Docker as browser |`/`
-|`sel.jup.android.default.version` | Default version of Android devices in Doker |`7.1.1`
+|`sel.jup.android.default.version` | Default version of Android devices in Docker |`7.1.1`
 |`sel.jup.android.image.api21.linux` | Docker image for version 5.0.1 of Android devices in Linux |`butomo1989/docker-android-x86-5.0.1:0.9-p5`
 |`sel.jup.android.image.api22.linux` | Docker image for version 5.1.1 of Android devices in Linux |`butomo1989/docker-android-x86-5.1.1:0.9-p5`
 |`sel.jup.android.image.api23.linux` | Docker image for version 6.0 of Android devices in Linux |`butomo1989/docker-android-x86-6.0:0.9-p5`
@@ -109,7 +109,7 @@ Moreover, the value of these properties can be overridden by means of environmen
 
 === Tuning WebDriverManager
 
-As introduced before, _Selenium-Jupiter_ internally uses https://github.com/bonigarcia/webdrivermanager[WebDriverManager] to manage the required binary to control localc browsers. This tool can be configured in several ways, for example to force using a given version of the binary (by default it tries to use the latest version), or force to use the cache (instead of connecting to the online repository to download the binary artifact). For further information about this configuration capabilities, please take a look to the https://github.com/bonigarcia/webdrivermanager[WebDriverManager documentation].
+As introduced before, _Selenium-Jupiter_ internally uses https://github.com/bonigarcia/webdrivermanager[WebDriverManager] to manage the required binary to control local browsers. This tool can be configured in several ways, for example to force using a given version of the binary (by default it tries to use the latest version), or force to use the cache (instead of connecting to the online repository to download the binary artifact). For further information about this configuration capabilities, please take a look to the https://github.com/bonigarcia/webdrivermanager[WebDriverManager documentation].
 
 In this section we are going to present a couple of simple examples tuning somehow WebDriverManger. The following example shows how to force a version number for a binary, concretely for Edge:
 

--- a/src/doc/asciidoc/remote-browsers.adoc
+++ b/src/doc/asciidoc/remote-browsers.adoc
@@ -7,7 +7,7 @@ _Selenium-Jupiter_ also supports remote browsers, using a http://www.seleniumhq.
 
 === Using capabilities
 
-The annotation `@DriverCapabilities` is used to specify WebDriver capabilities (i.e. type browser, version, platform, etc.). These capabilities are typically used for Selenium Grid tets (i.e. tests using remote browsers). To that aim, an Selenium Hub (also known as _Selenium Server_) should be up an running, and its URL should known. This URL will be specified using the _Selenium-Jupiter_ annotation `@DriverUrl`. 
+The annotation `@DriverCapabilities` is used to specify WebDriver capabilities (i.e. type browser, version, platform, etc.). These capabilities are typically used for Selenium Grid tests (i.e. tests using remote browsers). To that aim, a Selenium Hub (also known as _Selenium Server_) should be up an running, and its URL should known. This URL will be specified using the _Selenium-Jupiter_ annotation `@DriverUrl`. 
 
 The following example provides a complete https://github.com/bonigarcia/selenium-jupiter/blob/master/src/test/java/io/github/bonigarcia/test/advance/RemoteWebDriverJupiterTest.java[example] about this. As you can see, in the test setup (`@BeforeAll`) a Selenium Grid is implemented, first starting a Hub (a.k.a. _Selenium Server_), and then a couple of nodes (Chrome a Firefox) are registered in the Hub. Therefore, remote test using `RemoteWebDriver` can be executed, simply pointing to the Hub (whose URL in this case is `http://localhost:4444/wd/hub` in this example) and selecting the browser to be used using the `Capabilities`.
 


### PR DESCRIPTION
Fix typos in Advanced features, Configuration, and Remote browsers.