### PR TITLE
Get correct Capabilities type from Options

### DIFF
--- a/src/main/java/io/github/bonigarcia/handler/ChromeDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/handler/ChromeDriverHandler.java
@@ -96,10 +96,10 @@ public class ChromeDriverHandler extends DriverHandler {
             }
 
             // @Options
-            Object optionsFromAnnotatedField = annotationsReader
-                    .getOptionsFromAnnotatedField(testInstance, Options.class);
+            ChromeOptions optionsFromAnnotatedField = annotationsReader
+                    .getOptionsFromAnnotatedField(testInstance, Options.class, ChromeOptions.class);
             if (optionsFromAnnotatedField != null) {
-                chromeOptions = ((ChromeOptions) optionsFromAnnotatedField)
+                chromeOptions = optionsFromAnnotatedField
                         .merge(chromeOptions);
             }
         }

--- a/src/main/java/io/github/bonigarcia/handler/EdgeDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/handler/EdgeDriverHandler.java
@@ -62,10 +62,10 @@ public class EdgeDriverHandler extends DriverHandler {
             Optional<Object> testInstance)
             throws IOException, IllegalAccessException {
         EdgeOptions edgeOptions = new EdgeOptions();
-        Object optionsFromAnnotatedField = annotationsReader
-                .getOptionsFromAnnotatedField(testInstance, Options.class);
+        EdgeOptions optionsFromAnnotatedField = annotationsReader
+                .getOptionsFromAnnotatedField(testInstance, Options.class, EdgeOptions.class);
         if (optionsFromAnnotatedField != null) {
-            edgeOptions = (EdgeOptions) optionsFromAnnotatedField;
+            edgeOptions = optionsFromAnnotatedField;
         }
         return edgeOptions;
     }

--- a/src/main/java/io/github/bonigarcia/handler/FirefoxDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/handler/FirefoxDriverHandler.java
@@ -104,10 +104,10 @@ public class FirefoxDriverHandler extends DriverHandler {
             managePreferences(parameter, firefoxOptions);
 
             // @Options
-            Object optionsFromAnnotatedField = annotationsReader
-                    .getOptionsFromAnnotatedField(testInstance, Options.class);
+            FirefoxOptions optionsFromAnnotatedField = annotationsReader
+                    .getOptionsFromAnnotatedField(testInstance, Options.class, FirefoxOptions.class);
             if (optionsFromAnnotatedField != null) {
-                firefoxOptions = ((FirefoxOptions) optionsFromAnnotatedField)
+                firefoxOptions = optionsFromAnnotatedField
                         .merge(firefoxOptions);
             }
         }

--- a/src/main/java/io/github/bonigarcia/handler/OperaDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/handler/OperaDriverHandler.java
@@ -94,10 +94,10 @@ public class OperaDriverHandler extends DriverHandler {
             }
 
             // @Options
-            Object optionsFromAnnotatedField = annotationsReader
-                    .getOptionsFromAnnotatedField(testInstance, Options.class);
+            OperaOptions optionsFromAnnotatedField = annotationsReader
+                    .getOptionsFromAnnotatedField(testInstance, Options.class, OperaOptions.class);
             if (optionsFromAnnotatedField != null) {
-                operaOptions = ((OperaOptions) optionsFromAnnotatedField)
+                operaOptions = optionsFromAnnotatedField
                         .merge(operaOptions);
             }
         }

--- a/src/main/java/io/github/bonigarcia/handler/SafariDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/handler/SafariDriverHandler.java
@@ -60,10 +60,10 @@ public class SafariDriverHandler extends DriverHandler {
     public MutableCapabilities getOptions(Parameter parameter,
             Optional<Object> testInstance) throws IllegalAccessException {
         SafariOptions safariOptions = new SafariOptions();
-        Object optionsFromAnnotatedField = annotationsReader
-                .getOptionsFromAnnotatedField(testInstance, Options.class);
+        SafariOptions optionsFromAnnotatedField = annotationsReader
+                .getOptionsFromAnnotatedField(testInstance, Options.class, SafariOptions.class);
         if (optionsFromAnnotatedField != null) {
-            safariOptions = (SafariOptions) optionsFromAnnotatedField;
+            safariOptions = optionsFromAnnotatedField;
         }
         return safariOptions;
     }

--- a/src/test/java/io/github/bonigarcia/test/annotations/AnnotationsReaderTest.java
+++ b/src/test/java/io/github/bonigarcia/test/annotations/AnnotationsReaderTest.java
@@ -1,0 +1,144 @@
+/*
+ * (C) Copyright 2018 Boni Garcia (http://bonigarcia.github.io/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.bonigarcia.test.annotations;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Capabilities;
+
+import io.github.bonigarcia.AnnotationsReader;
+import io.github.bonigarcia.Options;
+import io.github.bonigarcia.SeleniumJupiterException;
+
+public class AnnotationsReaderTest {
+
+    private AnnotationsReader annotationsReader = new AnnotationsReader();
+    private Optional<Object> testInstance = Optional.of(new ClassWithOptions());
+
+    @Test
+    void testThrowsExceptionWithNullTestInstance() throws Exception {
+        assertThrows(NullPointerException.class, () -> {
+            annotationsReader.getOptionsFromAnnotatedField(null, Options.class);
+        });
+    }
+
+    @Test
+    void testThrowsExceptionWithNullCapabilitiesClass() throws Exception {
+        assertThrows(SeleniumJupiterException.class, () -> {
+            annotationsReader.getOptionsFromAnnotatedField(testInstance, Options.class, null);
+        }, "The parameter capabilitiesClass must not be null.");
+    }
+
+    @Test
+    void testGetsNullOptionsIfEmptyTestInstance() throws Exception {
+        Object options = annotationsReader.getOptionsFromAnnotatedField(Optional.empty(), Options.class);
+        assertThat(options, nullValue());
+    }
+
+    @Test
+    void testGetsFirstDeclaredOptionsFromAnnotatedFieldWithoutTypeSpecied() throws Exception {
+        Object options = annotationsReader.getOptionsFromAnnotatedField(testInstance, Options.class);
+        assertThat(options, instanceOf(Integer.class));
+    }
+
+    @Test
+    void testGetsNullOptionsFromAnnotatedFieldIfSpeciedTypeNotFound() throws Exception {
+        Capabilities options = annotationsReader.getOptionsFromAnnotatedField(testInstance, Options.class,
+                Capabilities.class);
+        assertThat(options, nullValue());
+    }
+
+    @Test
+    void testGetsOptionsFromAnnotatedFieldWithSpeciedType() throws Exception {
+        CapabilitiesA optionsA = annotationsReader.getOptionsFromAnnotatedField(testInstance, Options.class,
+                CapabilitiesA.class);
+        assertThat(optionsA, notNullValue());
+        assertThat(optionsA.getId(), equalTo("A"));
+
+        CapabilitiesB optionsB = annotationsReader.getOptionsFromAnnotatedField(testInstance, Options.class,
+                CapabilitiesB.class);
+        assertThat(optionsB, notNullValue());
+        assertThat(optionsB.getId(), equalTo("B"));
+    }
+
+    private static class ClassWithOptions {
+
+        @Options
+        Integer integer = 1;
+
+        @Options
+        CapabilitiesA capabilitiesA = new CapabilitiesA("A");
+
+        @Options
+        String string = "string";
+
+        @Options
+        CapabilitiesB capabilitiesB = new CapabilitiesB("B");
+
+        @Options
+        CapabilitiesA unreachable = new CapabilitiesA("unreachable");
+    }
+
+    private static class CapabilitiesA extends AbstractCapabilities {
+
+        public CapabilitiesA(String id) {
+            super(id);
+        }
+    }
+
+    private static class CapabilitiesB extends AbstractCapabilities {
+
+        public CapabilitiesB(String id) {
+            super(id);
+        }
+    }
+
+    private static abstract class AbstractCapabilities implements Capabilities {
+
+        private static final Map<String, Object> capabilities = new HashMap<>();
+
+        private final String id;
+
+        public AbstractCapabilities(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        @Override
+        public Map<String, ?> asMap() {
+            return capabilities;
+        }
+
+        @Override
+        public Object getCapability(String capabilityName) {
+            return capabilities.get(capabilityName);
+        }
+    }
+}

--- a/src/test/java/io/github/bonigarcia/test/annotations/ClassWithMultipleOptions.java
+++ b/src/test/java/io/github/bonigarcia/test/annotations/ClassWithMultipleOptions.java
@@ -1,0 +1,42 @@
+/*
+ * (C) Copyright 2018 Boni Garcia (http://bonigarcia.github.io/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.bonigarcia.test.annotations;
+
+import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.opera.OperaOptions;
+import org.openqa.selenium.safari.SafariOptions;
+
+import io.github.bonigarcia.Options;
+
+public class ClassWithMultipleOptions {
+
+    @Options
+    Object options = new Object();
+
+    @Options
+    EdgeOptions edgeOptions = new EdgeOptions();
+
+    @Options
+    FirefoxOptions firefoxOptions = new FirefoxOptions();
+    
+    @Options
+    OperaOptions operaOptions = new OperaOptions();
+
+    @Options
+    SafariOptions safariOptions = new SafariOptions();
+}

--- a/src/test/java/io/github/bonigarcia/test/annotations/EdgeAnnotationReaderTest.java
+++ b/src/test/java/io/github/bonigarcia/test/annotations/EdgeAnnotationReaderTest.java
@@ -17,12 +17,14 @@
 package io.github.bonigarcia.test.annotations;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Parameter;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -56,4 +58,10 @@ public class EdgeAnnotationReaderTest {
                 equalTo("eager"));
     }
 
+    @Test
+    void testAnnotatedEdgeOptionsIsSelectedOverOtherAnnotatedOptions() throws Exception {
+        Optional<Object> testInstance = Optional.of(new ClassWithMultipleOptions());
+        EdgeOptions edgeOptions = (EdgeOptions) annotationsReader.getOptions(null, testInstance);
+        assertThat(edgeOptions, notNullValue());
+    }
 }

--- a/src/test/java/io/github/bonigarcia/test/annotations/FirefoxAnnotationReaderTest.java
+++ b/src/test/java/io/github/bonigarcia/test/annotations/FirefoxAnnotationReaderTest.java
@@ -16,6 +16,8 @@
  */
 package io.github.bonigarcia.test.annotations;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openqa.selenium.firefox.FirefoxOptions.FIREFOX_OPTIONS;
 
@@ -24,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -66,4 +69,10 @@ public class FirefoxAnnotationReaderTest {
         assertTrue(options.get("prefs").get("media.navigator.streams.fake"));
     }
 
+    @Test
+    void testAnnotatedFirefoxOptionsIsSelectedOverOtherAnnotatedOptions() throws Exception {
+        Optional<Object> testInstance = Optional.of(new ClassWithMultipleOptions());
+        FirefoxOptions firefoxOptions = (FirefoxOptions) annotationsReader.getOptions(null, testInstance);
+        assertThat(firefoxOptions, notNullValue());
+    }
 }

--- a/src/test/java/io/github/bonigarcia/test/annotations/OperaAnnotationReaderTest.java
+++ b/src/test/java/io/github/bonigarcia/test/annotations/OperaAnnotationReaderTest.java
@@ -18,9 +18,11 @@ package io.github.bonigarcia.test.annotations;
 
 import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Parameter;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
@@ -56,4 +58,10 @@ public class OperaAnnotationReaderTest {
                 containsString("binary"));
     }
 
+    @Test
+    void testAnnotatedOperaOptionsIsSelectedOverOtherAnnotatedOptions() throws Exception {
+        Optional<Object> testInstance = Optional.of(new ClassWithMultipleOptions());
+        OperaOptions operaOptions = (OperaOptions) annotationsReader.getOptions(null, testInstance);
+        assertThat(operaOptions, notNullValue());
+    }
 }

--- a/src/test/java/io/github/bonigarcia/test/annotations/SafariAnnotationReaderTest.java
+++ b/src/test/java/io/github/bonigarcia/test/annotations/SafariAnnotationReaderTest.java
@@ -16,12 +16,15 @@
  */
 package io.github.bonigarcia.test.annotations;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.lang.reflect.Parameter;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,5 +56,12 @@ public class SafariAnnotationReaderTest {
                 .getOptions(parameter, testInstance);
 
         assertFalse(safariOptions.getUseTechnologyPreview());
+    }
+
+    @Test
+    void testAnnotatedSafariOptionsIsSelectedOverOtherAnnotatedOptions() throws Exception {
+        Optional<Object> testInstance = Optional.of(new ClassWithMultipleOptions());
+        SafariOptions safariOptions = (SafariOptions) annotationsReader.getOptions(null, testInstance);
+        assertThat(safariOptions, notNullValue());
     }
 }


### PR DESCRIPTION
Change AnnotationsReader to allow to get the annotated Options of a
given type, to allow multiple configuration Options in the same test
class. Previously it would lead to a ClassCastException since it assumed
a single annotated Options.
Update DriverHandler implementations to request the corresponding type
(e.g. EdgeOptions for EdgeDriverHandler).

---
This supports our use case mentioned here https://stackoverflow.com/questions/53224694/selenium-jupiter-how-to-set-firefox-and-chrome-options