### PR TITLE
Add sel.jup.docker.host config parameter

### DIFF
--- a/src/doc/asciidoc/configuration.adoc
+++ b/src/doc/asciidoc/configuration.adoc
@@ -98,6 +98,7 @@ Default configuration parameters for _Selenium-Jupiter_ are set in the https://g
 |`sel.jup.docker.hub.url` | Docker Hub URL |`https://hub.docker.com/`
 |`sel.jup.docker.stop.timeout.sec` |  Timeout in seconds to stop Docker containers at the end of tests |`0`
 |`sel.jup.docker.api.version` | Docker API version |`1.35`
+|`sel.jup.docker.host` | Host to use when connecting to exposed docker port instead of dynamic lookup |
 |`sel.jup.docker.network` | Docker network |`bridge`
 |`sel.jup.docker.timezone` | Timezone for browsers in Docker containers |`Europe/Madrid`
 |`sel.jup.docker.lang` | Language for Docker containers |`en`

--- a/src/main/java/io/github/bonigarcia/seljup/DockerService.java
+++ b/src/main/java/io/github/bonigarcia/seljup/DockerService.java
@@ -89,6 +89,11 @@ public class DockerService {
 
     public String getHost(String containerId, String network)
             throws DockerException, InterruptedException {
+        String dockerHost = getConfig().getDockerHost();
+        if( !dockerHost.isEmpty() ) {
+            return dockerHost;
+        }
+
         return IS_OS_LINUX
                 ? dockerClient.inspectContainer(containerId).networkSettings()
                         .networks().get(network).gateway()

--- a/src/main/java/io/github/bonigarcia/seljup/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/seljup/config/Config.java
@@ -162,6 +162,8 @@ public class Config {
             "sel.jup.docker.stop.timeout.sec", Integer.class);
     ConfigKey<String> dockerApiVersion = new ConfigKey<>(
             "sel.jup.docker.api.version", String.class);
+    ConfigKey<String> dockerHost = new ConfigKey<>("sel.jup.docker.host",
+            String.class);
     ConfigKey<String> dockerNetwork = new ConfigKey<>("sel.jup.docker.network",
             String.class);
     ConfigKey<String> dockerTimeZone = new ConfigKey<>(
@@ -809,6 +811,14 @@ public class Config {
 
     public void setDockerApiVersion(String value) {
         this.dockerApiVersion.setValue(value);
+    }
+
+    public String getDockerHost() {
+        return resolve(dockerHost);
+    }
+
+    public void setDockerHost(String value) {
+        this.dockerHost.setValue(value);
     }
 
     public String getDockerNetwork() {


### PR DESCRIPTION
Fixes #56

This fixes the issue running under WSL referenced in #56 by adding a configuration parameter to force the host used when connecting to the exposed docker port.
