### PR TITLE
Allow @SingleSession to be inherited

### DIFF
--- a/src/main/java/io/github/bonigarcia/seljup/SingleSession.java
+++ b/src/main/java/io/github/bonigarcia/seljup/SingleSession.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Target;
  * @since 3.2.0
  */
 @Retention(RUNTIME)
+@Inherited
 @Target(TYPE)
 public @interface SingleSession {
 

--- a/src/main/java/io/github/bonigarcia/seljup/SingleSession.java
+++ b/src/main/java/io/github/bonigarcia/seljup/SingleSession.java
@@ -19,6 +19,7 @@ package io.github.bonigarcia.seljup;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 


### PR DESCRIPTION
This allows a parent class to set up all the browser settings in one place, then subclasses reuse them for the actual tests.