### PR TITLE
Allow inherited methods to use docker browsers

### DIFF
--- a/src/main/java/io/github/bonigarcia/seljup/handler/DockerDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/seljup/handler/DockerDriverHandler.java
@@ -998,8 +998,8 @@ public class DockerDriverHandler {
                     Parameter[] parameters = constructor.getParameters();
                     count += getDockerBrowsersInParams(parameters);
                 }
-                Method[] declaredMethods = testClass.get().getDeclaredMethods();
-                for (Method method : declaredMethods) {
+                Method[] methods = testClass.get().getMethods();
+                for (Method method : methods) {
                     Parameter[] parameters = method.getParameters();
                     count += getDockerBrowsersInParams(parameters);
                 }


### PR DESCRIPTION
This allows for using a base class to keep initialization in one place and run actual tests in a subclass. Right now only the sub-class's methods are checked for docker drivers to add to the limit, even though parent class methods will still trigger SeleniumExtensions's ParameterResolver. The result is a hang when trying to create the session.

Here's an example use-case:

```java
@ExtendWith( SeleniumExtension.class )
@TestInstance( Lifecycle.PER_CLASS )
@SingleSession
@Slf4j
public class SuperClass {

    protected RemoteWebDriver driver;

    @Options
    public ChromeOptions chromeOptions = new ChromeOptions();

    {
        Proxy proxy = new Proxy();
        proxy.setHttpProxy( "localhostproxy:8881" );
        chromeOptions.setProxy( proxy );
    }
    
    @BeforeAll
    public void superBeforeAll( RemoteWebDriver driver ) {
        log.info( "superBeforeAll()" );
        driver.manage().addCookie( new Cookie( "auth", "secretkey" ) );
        this.driver = driver;
    }
    
    @Slf4j
    public static class SubClassTest extends SuperClass {

        @Test
        public void httpTest() {
            log.info( "SubClass httpTest()" );
            driver.get( "http://neverssl.com/" );
            Assertions.assertThat( driver.getTitle() ).contains( "NeverSSL" );
        }
    }

}
```

(In our case we have many sub-classes that use the common setup in the parent class)