### PR TITLE
Appium Logging Configuration

### DIFF
--- a/src/doc/asciidoc/configuration.adoc
+++ b/src/doc/asciidoc/configuration.adoc
@@ -88,6 +88,7 @@ Default configuration parameters for _Selenium-Jupiter_ are set in the https://g
 |`sel.jup.android.appium.ping.period.sec` | Amount of time that should pass after failed attempt to initialize Appium before the next attempt |`10`
 |`sel.jup.android.logging` | If true Android and Appium log files will be written into `sel.jup.android.logs.folder` directory |`false`
 |`sel.jup.android.logs.folder` | Folder with Android logs relative to `sel.jup.output.folder`. It contains files such as _appium.log_ (Appium server log) or _docker-android.stdout.log_ (Android emulator log) |`androidLogs`
+|`sel.jup.android.appium.loglevel` | Log level for Appium console and logfile (`console[:file]`), either `debug`, `info`, `warn`, or `error`  |`debug:debug`
 |`sel.jup.android.screen.width` | Android device screen width (in pixels) |`1900`
 |`sel.jup.android.screen.height` | Android device screen height (in pixels) |`900`
 |`sel.jup.android.screen.depth` | Android device screen color depth |`24+32`

--- a/src/doc/asciidoc/configuration.adoc
+++ b/src/doc/asciidoc/configuration.adoc
@@ -88,7 +88,7 @@ Default configuration parameters for _Selenium-Jupiter_ are set in the https://g
 |`sel.jup.android.appium.ping.period.sec` | Amount of time that should pass after failed attempt to initialize Appium before the next attempt |`10`
 |`sel.jup.android.logging` | If true Android and Appium log files will be written into `sel.jup.android.logs.folder` directory |`false`
 |`sel.jup.android.logs.folder` | Folder with Android logs relative to `sel.jup.output.folder`. It contains files such as _appium.log_ (Appium server log) or _docker-android.stdout.log_ (Android emulator log) |`androidLogs`
-|`sel.jup.android.appium.loglevel` | Log level for Appium console and logfile (`console[:file]`), either `debug`, `info`, `warn`, or `error`  |`debug:debug`
+|`sel.jup.android.appium.loglevel` | Log level for Appium console and logfile (`console[:file]`), either `debug`, `info`, `warn`, or `error`  |`debug`
 |`sel.jup.android.screen.width` | Android device screen width (in pixels) |`1900`
 |`sel.jup.android.screen.height` | Android device screen height (in pixels) |`900`
 |`sel.jup.android.screen.depth` | Android device screen color depth |`24+32`

--- a/src/doc/asciidoc/configuration.adoc
+++ b/src/doc/asciidoc/configuration.adoc
@@ -89,6 +89,7 @@ Default configuration parameters for _Selenium-Jupiter_ are set in the https://g
 |`sel.jup.android.logging` | If true Android and Appium log files will be written into `sel.jup.android.logs.folder` directory |`false`
 |`sel.jup.android.logs.folder` | Folder with Android logs relative to `sel.jup.output.folder`. It contains files such as _appium.log_ (Appium server log) or _docker-android.stdout.log_ (Android emulator log) |`androidLogs`
 |`sel.jup.android.appium.loglevel` | Log level for Appium console and logfile (`console[:file]`), either `debug`, `info`, `warn`, or `error`  |`debug`
+|`sel.jup.android.appium.logfile` | Log file for Appium output |
 |`sel.jup.android.screen.width` | Android device screen width (in pixels) |`1900`
 |`sel.jup.android.screen.height` | Android device screen height (in pixels) |`900`
 |`sel.jup.android.screen.depth` | Android device screen color depth |`24+32`

--- a/src/main/java/io/github/bonigarcia/seljup/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/seljup/config/Config.java
@@ -227,6 +227,8 @@ public class Config {
             "sel.jup.android.logging", Boolean.class);
     ConfigKey<String> androidLogsFolder = new ConfigKey<>(
             "sel.jup.android.logs.folder", String.class);
+    ConfigKey<String> androidAppiumLogLevel  = new ConfigKey<>(
+            "sel.jup.android.appium.loglevel", String.class);
     ConfigKey<String> androidScreenWidth = new ConfigKey<>(
             "sel.jup.android.screen.width", String.class);
     ConfigKey<String> androidScreenHeigth = new ConfigKey<>(
@@ -1068,6 +1070,14 @@ public class Config {
 
     public void setAndroidLogsFolder(String androidLogsFolder) {
         this.androidLogsFolder.setValue(androidLogsFolder);
+    }
+
+    public String getAndroidAppiumLogLevel() {
+        return resolve(androidAppiumLogLevel);
+    }
+
+    public void setAndroidAppiumLogLevel(String androidAppiumLogLevel) {
+        this.androidAppiumLogLevel.setValue(androidAppiumLogLevel);
     }
 
     public String getAndroidScreenWidth() {

--- a/src/main/java/io/github/bonigarcia/seljup/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/seljup/config/Config.java
@@ -228,7 +228,9 @@ public class Config {
     ConfigKey<String> androidLogsFolder = new ConfigKey<>(
             "sel.jup.android.logs.folder", String.class);
     ConfigKey<String> androidAppiumLogLevel  = new ConfigKey<>(
-            "sel.jup.android.appium.loglevel", String.class, "debug");
+            "sel.jup.android.appium.loglevel", String.class);
+    ConfigKey<String> androidAppiumLogFile  = new ConfigKey<>(
+            "sel.jup.android.appium.logfile", String.class);
     ConfigKey<String> androidScreenWidth = new ConfigKey<>(
             "sel.jup.android.screen.width", String.class);
     ConfigKey<String> androidScreenHeigth = new ConfigKey<>(
@@ -1080,6 +1082,14 @@ public class Config {
         this.androidAppiumLogLevel.setValue(androidAppiumLogLevel);
     }
 
+    public String getAndroidAppiumLogFile() {
+        return resolve(androidAppiumLogFile);
+    }
+
+    public void setAndroidAppiumLogFile(String androidAppiumLogFile) {
+        this.androidAppiumLogFile.setValue(androidAppiumLogFile);
+    }
+
     public String getAndroidScreenWidth() {
         return resolve(androidScreenWidth);
     }
@@ -1207,5 +1217,4 @@ public class Config {
     public WebDriverManager phantomjs() {
         return WebDriverManager.phantomjs();
     }
-
 }

--- a/src/main/java/io/github/bonigarcia/seljup/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/seljup/config/Config.java
@@ -228,7 +228,7 @@ public class Config {
     ConfigKey<String> androidLogsFolder = new ConfigKey<>(
             "sel.jup.android.logs.folder", String.class);
     ConfigKey<String> androidAppiumLogLevel  = new ConfigKey<>(
-            "sel.jup.android.appium.loglevel", String.class, "debug:debug");
+            "sel.jup.android.appium.loglevel", String.class, "debug");
     ConfigKey<String> androidScreenWidth = new ConfigKey<>(
             "sel.jup.android.screen.width", String.class);
     ConfigKey<String> androidScreenHeigth = new ConfigKey<>(

--- a/src/main/java/io/github/bonigarcia/seljup/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/seljup/config/Config.java
@@ -228,7 +228,7 @@ public class Config {
     ConfigKey<String> androidLogsFolder = new ConfigKey<>(
             "sel.jup.android.logs.folder", String.class);
     ConfigKey<String> androidAppiumLogLevel  = new ConfigKey<>(
-            "sel.jup.android.appium.loglevel", String.class);
+            "sel.jup.android.appium.loglevel", String.class, "debug:debug");
     ConfigKey<String> androidScreenWidth = new ConfigKey<>(
             "sel.jup.android.screen.width", String.class);
     ConfigKey<String> androidScreenHeigth = new ConfigKey<>(

--- a/src/main/java/io/github/bonigarcia/seljup/handler/AppiumDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/seljup/handler/AppiumDriverHandler.java
@@ -16,6 +16,8 @@
  */
 package io.github.bonigarcia.seljup.handler;
 
+import io.appium.java_client.service.local.AppiumServiceBuilder;
+import io.appium.java_client.service.local.flags.GeneralServerFlag;
 import java.lang.reflect.Parameter;
 import java.net.URL;
 import java.util.Optional;
@@ -58,8 +60,9 @@ public class AppiumDriverHandler extends DriverHandler {
                 if (url.isPresent()) {
                     appiumServerUrl = url.get();
                 } else {
-                    appiumDriverLocalService = AppiumDriverLocalService
-                            .buildDefaultService();
+                    AppiumServiceBuilder builder = new AppiumServiceBuilder();
+                    builder.withArgument(GeneralServerFlag.LOG_LEVEL, config.getAndroidAppiumLogLevel());
+                    appiumDriverLocalService = AppiumDriverLocalService.buildService(builder);
                     appiumDriverLocalService.start();
                     appiumServerUrl = appiumDriverLocalService.getUrl();
                 }

--- a/src/main/java/io/github/bonigarcia/seljup/handler/AppiumDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/seljup/handler/AppiumDriverHandler.java
@@ -18,6 +18,7 @@ package io.github.bonigarcia.seljup.handler;
 
 import io.appium.java_client.service.local.AppiumServiceBuilder;
 import io.appium.java_client.service.local.flags.GeneralServerFlag;
+import java.io.File;
 import java.lang.reflect.Parameter;
 import java.net.URL;
 import java.util.Optional;
@@ -61,7 +62,17 @@ public class AppiumDriverHandler extends DriverHandler {
                     appiumServerUrl = url.get();
                 } else {
                     AppiumServiceBuilder builder = new AppiumServiceBuilder();
-                    builder.withArgument(GeneralServerFlag.LOG_LEVEL, config.getAndroidAppiumLogLevel());
+
+                    String logLevel = config.getAndroidAppiumLogLevel();
+                    if(!logLevel.equals("")) {
+                        builder.withArgument(GeneralServerFlag.LOG_LEVEL, logLevel);
+                    }
+
+                    String appiumLogFile = config.getAndroidAppiumLogFile();
+                    if(!appiumLogFile.equals("")) {
+                        builder.withLogFile(new File(appiumLogFile));
+                    }
+
                     appiumDriverLocalService = AppiumDriverLocalService.buildService(builder);
                     appiumDriverLocalService.start();
                     appiumServerUrl = appiumDriverLocalService.getUrl();

--- a/src/test/java/io/github/bonigarcia/seljup/test/appium/AppiumApkLogLevelJupiterTest.java
+++ b/src/test/java/io/github/bonigarcia/seljup/test/appium/AppiumApkLogLevelJupiterTest.java
@@ -47,7 +47,7 @@ public class AppiumApkLogLevelJupiterTest {
     @BeforeEach
     void setupSelenium() {
         seleniumExtension.getConfig().setAndroidAppiumLogLevel("error:debug");
-        seleniumExtension.getConfig().setAndroidAppiumLogFile("appiumLog");
+        seleniumExtension.getConfig().setAndroidAppiumLogFile("appium.log");
     }
 
     @DriverCapabilities

--- a/src/test/java/io/github/bonigarcia/seljup/test/appium/AppiumApkLogLevelJupiterTest.java
+++ b/src/test/java/io/github/bonigarcia/seljup/test/appium/AppiumApkLogLevelJupiterTest.java
@@ -47,6 +47,7 @@ public class AppiumApkLogLevelJupiterTest {
     @BeforeEach
     void setupSelenium() {
         seleniumExtension.getConfig().setAndroidAppiumLogLevel("error:debug");
+        seleniumExtension.getConfig().setAndroidAppiumLogFile("appiumLog");
     }
 
     @DriverCapabilities

--- a/src/test/java/io/github/bonigarcia/seljup/test/appium/AppiumApkLogLevelJupiterTest.java
+++ b/src/test/java/io/github/bonigarcia/seljup/test/appium/AppiumApkLogLevelJupiterTest.java
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2017 Boni Garcia (http://bonigarcia.github.io/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.bonigarcia.seljup.test.appium;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.MobileElement;
+import io.github.bonigarcia.seljup.DriverCapabilities;
+import io.github.bonigarcia.seljup.SeleniumExtension;
+import java.io.File;
+import java.net.URISyntaxException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+// end::snippet-in-doc[]
+@Disabled("Android emulator not available on Travis CI")
+// tag::snippet-in-doc[]
+public class AppiumApkLogLevelJupiterTest {
+
+    @RegisterExtension
+    static SeleniumExtension seleniumExtension = new SeleniumExtension();
+
+    /**
+     * Configure Selenium to use a custom log level
+     */
+    @BeforeEach
+    void setupSelenium() {
+        seleniumExtension.getConfig().setAndroidAppiumLogLevel("error:debug");
+    }
+
+    @DriverCapabilities
+    DesiredCapabilities capabilities = new DesiredCapabilities();
+    {
+        try {
+            File apk = new File(this.getClass()
+                    .getResource("/selendroid-test-app.apk").toURI());
+            capabilities.setCapability("app", apk.getAbsolutePath());
+            capabilities.setCapability("deviceName", "Android");
+
+        } catch (URISyntaxException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Test
+    void testWithAndroid(AppiumDriver<MobileElement> driver)
+            throws InterruptedException {
+        WebElement button = driver.findElement(By.id("buttonStartWebview"));
+        assertThat(button, notNullValue());
+        button.click();
+
+        WebElement inputField = driver.findElement(By.id("name_input"));
+        inputField.clear();
+        inputField.sendKeys("Custom name");
+    }
+
+}
+// end::snippet-in-doc[]


### PR DESCRIPTION
### Purpose of changes
Allows overriding the default Appium log level configuration, as requested in #63, as well as the ability to specify a file to which to save Appium logs.

### Type of changes

- [x] New feature (non-breaking change which adds functionality)

### How has this been tested?
* Ran the Selenium-Jupiter test suite locally, along with adding a new test `AppiumApkLogLevelJupiterTest`
* Added a snapshot as a dependency for my local Selenium project and it functioned as expected.