### PR TITLE
Add class name to screenshot filename if method name unavailable

### DIFF
--- a/src/main/java/io/github/bonigarcia/seljup/handler/DriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/seljup/handler/DriverHandler.java
@@ -81,6 +81,11 @@ public abstract class DriverHandler {
         Optional<Method> testMethod = context.getTestMethod();
         if (testMethod.isPresent()) {
             name = testMethod.get().getName() + "_";
+        } else {
+            Optional<Class<?>> testClass = context.getTestClass();
+            if (testClass.isPresent()) {
+                name = testClass.get().getSimpleName() + "_";
+            }
         }
         name += parameter.getName() + "_" + object.getClass().getSimpleName();
         if (RemoteWebDriver.class.isAssignableFrom(object.getClass())) {

--- a/src/test/java/io/github/bonigarcia/seljup/test/singlessession/ScreenshotNamedWithClassTest.java
+++ b/src/test/java/io/github/bonigarcia/seljup/test/singlessession/ScreenshotNamedWithClassTest.java
@@ -1,0 +1,44 @@
+package io.github.bonigarcia.seljup.test.singlessession;
+
+import io.github.bonigarcia.seljup.SeleniumExtension;
+import io.github.bonigarcia.seljup.SingleSession;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@SingleSession
+@Disabled
+public class ScreenshotNamedWithClassTest {
+
+    @RegisterExtension
+    static SeleniumExtension seleniumExtension = new SeleniumExtension();
+
+    RemoteWebDriver driver;
+
+    @BeforeAll
+    void setup() {
+        seleniumExtension.getConfig()
+                .setScreenshotAtTheEndOfTests("whenfailure");
+        seleniumExtension.getConfig().takeScreenshotAsPng();
+    }
+
+    @BeforeAll
+    void resolveWebDriver(ChromeDriver webDriver) {
+        this.driver = webDriver;
+    }
+
+    @Test
+    void shouldFailAndCreateScreenshotTest() {
+        driver.get("https://bonigarcia.github.io/selenium-jupiter/");
+        assertThat(driver.getTitle(),
+                containsString("Test should fail and create screenshot"));
+    }
+
+}


### PR DESCRIPTION
### Purpose of changes

If the webDriver is resolved using @BeforeAll, then the JUnit
context doesn't have access to the method name, resulting in
a screenshot file that doesn't indicate which test failed, e.g.:

arg0_ChromeDriver_5f68924932fe6bf908d886cdfb7f66bc.png

Since the context has the class name, prepend the name with the
class name, e.g:

ScreenshotNamedWithClassTest_arg0_ChromeDriver_5f68924932fe6bf908d886cdfb7f66bc.png

### Types of changes

- [X] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Wrote disabled test case to test the scenario, verified that resulting png file is prepended with class name