### PR TITLE
#76 Recording not deleted when using different outputFolder

### DIFF
--- a/src/main/java/io/github/bonigarcia/seljup/handler/DockerDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/seljup/handler/DockerDriverHandler.java
@@ -1189,7 +1189,7 @@ public class DockerDriverHandler {
             move(recordingFile.toPath(),
                     recordingFile.toPath().resolveSibling(newRecordingName),
                     REPLACE_EXISTING);
-            recordingFile = new File(newRecordingName);
+            recordingFile = hostVideoFolder.toPath().resolve(newRecordingName).toFile();
         }
     }
 


### PR DESCRIPTION
### Purpose of changes
Fixing the path of the renamed record to be then deletable later.

### Types of changes

- [x] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Manually