### PR TITLE
compatibility with wsl2 docker desktop

### DIFF
--- a/src/main/java/io/github/bonigarcia/seljup/handler/DockerDriverHandler.java
+++ b/src/main/java/io/github/bonigarcia/seljup/handler/DockerDriverHandler.java
@@ -1136,6 +1136,7 @@ public class DockerDriverHandler {
             fileString = toLowerCase(fileString.charAt(0))
                     + fileString.substring(1);
             fileString = fileString.replace("\\\\", "/");
+            fileString = fileString.replace("\\", "/");
             fileString = fileString.replace(":", "");
             fileString = "/" + fileString;
         }


### PR DESCRIPTION
### Purpose of changes
Fixes https://github.com/bonigarcia/selenium-jupiter/issues/70 after last update of docker desktop 2.3.2.0 fix is quite simple and backward compatible

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [x] Bug-fix (non-breaking change which fixes an issue)


### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
running on docker desktop (docker for windows) with hyper-v and wsl2 backend