### PR TITLE
New config property: Separate recording output folders per class

### DIFF
--- a/src/doc/asciidoc/index.adoc
+++ b/src/doc/asciidoc/index.adoc
@@ -329,7 +329,9 @@ The following table describes all the possible Java methods in the Selenium-Jupi
 [options="header"]
 |=======
 |Java API|Configuration key|Default value|Description
-|`setOutputFolder(String)` `useSurefireOutputFolder()`|`sel.jup.output.folder`|`.`|Output folder for recordings and screenshots. This key accepts the special value `surefire-reports` for the <<integration-with-jenkins,integration with Jenkins>>
+|`setOutputFolder(String)` `useSurefireOutputFolder()`|`sel.jup.output.folder`|`.`|Output folder for recordings and screenshots. This key accepts the special value `surefire-reports` for the <<integration-with-jenkins,integration with Jenkins>>. In case of the special value `surefire-reports` there will *always* be a separate output folder per class (see below, `setOutputFolderPerClass(boolean)`).
+|`setOutputFolderPerClass(boolean)`|`sel.jup.output.folder.per.class`|`false`|In case this value is `true`, the output files will be provided in separate folders per class. Otherwise, the output files
+ will be directly provided in the output folder.
 |`setScreenshot(boolean)` `enableScreenshot()`|`sel.jup.screenshot`|`false`|Enable screenshots at the end of the test
 |`setScreenshotWhenFailure(boolean)` `enableScreenshotWhenFailure()`|`sel.jup.screenshot.when.failure`|`false`|Enable screenshots at the end of the test only if the test fails
 |`setScreenshotFormat(String)` `takeScreenshotAsPng()` `takeScreenshotAsBase64()` `takeScreenshotAsBase64AndPng()`|`sel.jup.screenshot.format`|`png`|Configure screenshot format (accepted values: `png`, `base`, and `base64andpng`)

--- a/src/main/java/io/github/bonigarcia/seljup/config/Config.java
+++ b/src/main/java/io/github/bonigarcia/seljup/config/Config.java
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2018 Boni Garcia (https://bonigarcia.github.io/)
+ * (C) Copyright 2022 Bosch.IO GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,8 +47,12 @@ public class Config {
 
     ConfigKey<String> properties = new ConfigKey<>("sel.jup.properties",
             String.class, "selenium-jupiter.properties");
+
     ConfigKey<String> outputFolder = new ConfigKey<>("sel.jup.output.folder",
             String.class);
+
+    ConfigKey<Boolean> outputFolderPerClass = new ConfigKey<>("sel.jup.output.folder.per.class",
+            Boolean.class);
 
     ConfigKey<String> seleniumServerUrl = new ConfigKey<>(
             "sel.jup.selenium.server.url", String.class);
@@ -170,6 +175,14 @@ public class Config {
 
     public void setOutputFolder(String value) {
         this.outputFolder.setValue(value);
+    }
+
+    public boolean isOutputFolderPerClass() {
+        return resolve(outputFolderPerClass);
+    }
+
+    public void setOutputFolderPerClass(boolean value) {
+        this.outputFolderPerClass.setValue(value);
     }
 
     public boolean isVnc() {

--- a/src/test/java/io/github/bonigarcia/seljup/test/screenshot/ScreenshotOutputFolderPerClassTest.java
+++ b/src/test/java/io/github/bonigarcia/seljup/test/screenshot/ScreenshotOutputFolderPerClassTest.java
@@ -1,0 +1,74 @@
+/*
+ * (C) Copyright 2022 Bosch.IO GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package io.github.bonigarcia.seljup.test.screenshot;
+
+import io.github.bonigarcia.seljup.SeleniumJupiter;
+import io.github.bonigarcia.seljup.config.Config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.remote.SessionId;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScreenshotOutputFolderPerClassTest {
+
+    private static final String RECORDINGS_FOLDER = "./target/recordings";
+
+    @RegisterExtension
+    static SeleniumJupiter seleniumJupiter = new SeleniumJupiter();
+
+    SessionId sessionId;
+
+    @BeforeAll
+    static void setup() {
+        Config config = seleniumJupiter.getConfig();
+
+        config.enableScreenshot();
+        config.takeScreenshotAsPng();
+        config.setOutputFolder(RECORDINGS_FOLDER);
+        config.setOutputFolderPerClass(true);
+    }
+
+    @AfterEach
+    void teardown() {
+        File[] files = new File(
+                 RECORDINGS_FOLDER + File.separator + this.getClass().getName())
+                        .listFiles();
+        Optional<File> screenshot = Arrays.stream(files).filter(
+                f -> f.getName().endsWith(sessionId.toString() + ".png"))
+                .findFirst();
+        assertThat(screenshot).isNotEmpty();
+        screenshot.get().delete();
+    }
+
+    @Test
+    void screenshotTest(ChromeDriver driver) {
+        driver.get("https://bonigarcia.dev/selenium-webdriver-java/");
+        assertThat(driver.getTitle()).contains("Selenium WebDriver");
+
+        sessionId = driver.getSessionId();
+    }
+
+}


### PR DESCRIPTION
Separate recording output folders per class not only for surefire-config, but for every folder, if config property outputFolderPerClass is true

Closes #217

### Purpose of changes
Closes #217

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
Added new test io.github.bonigarcia.seljup.test.screenshot.ScreenshotOutputFolderPerClassTest