### PR TITLE
Let @SingleSession supports meta-present

### DIFF
--- a/src/main/java/io/github/bonigarcia/seljup/SeleniumJupiter.java
+++ b/src/main/java/io/github/bonigarcia/seljup/SeleniumJupiter.java
@@ -749,8 +749,9 @@ public class SeleniumJupiter implements ParameterResolver,
         boolean singleSession = false;
         Optional<Class<?>> testClass = extensionContext.getTestClass();
         if (testClass.isPresent()) {
-            singleSession = testClass.get()
-                    .isAnnotationPresent(SingleSession.class);
+            singleSession =
+                findAnnotation(testClass.get(), SingleSession.class)
+                        .isPresent();
         }
         log.trace("Single session {}", singleSession);
         return singleSession;


### PR DESCRIPTION
### Purpose of changes
The `@SingleSession` annotation ever supports meta-present in #84 but was removed in bd6e0da7447ee379f82bfcbd448d8f044826ec46. I would like it to supports meta-present again.

### Types of changes

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?

Below code should run without error.

```
@Target(TYPE)
@Retention(RUNTIME)
@Inherited
@SingleSession
@TestInstance(Lifecycle.PER_CLASS)
@Execution(ExecutionMode.SAME_THREAD)
@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@ExtendWith(SeleniumJupiter.class)
public @interface ScenarioTest {

}

@ScenarioTest
public class SomeTestClass {

    private static WebDriver driver;

    @BeforeAll
    public static void login(ChromeDriver driver) {
        SomeTestClass.driver = driver;
    }

    @Test
    @Order(1)
    public void step1() {
        driver.get("https://www.google.com");
    }

    @Test
    @Order(2)
    public void step2() {
        driver.get("https://www.yahoo.com");
    }
}
```