### PR TITLE
Let HtmlUnitDriver be chosen as a substitute to Selenium WebDriver

### DIFF
--- a/src/main/java/io/github/bonigarcia/seljup/SeleniumJupiter.java
+++ b/src/main/java/io/github/bonigarcia/seljup/SeleniumJupiter.java
@@ -165,6 +165,9 @@ public class SeleniumJupiter implements ParameterResolver,
 
         // Selenium WebDriver
         default:
+            if ("HTMLUNIT".equalsIgnoreCase(System.getProperty("wdm.defaultBrowser"))) {
+                return resolveHtmlUnit(type, extensionContext, parameter);
+            }
             return resolveSeleniumWebDriver(extensionContext, contextId,
                     parameter, index, testInstance, type);
         }
@@ -300,16 +303,19 @@ public class SeleniumJupiter implements ParameterResolver,
             ExtensionContext extensionContext, Parameter parameter) {
         WebDriver driver = null;
         try {
-            Optional<Capabilities> capabilities = getCapabilities(
-                    extensionContext, parameter, Optional.empty(),
-                    Optional.empty());
+            Optional<Capabilities> capabilities = Optional.empty();
+            if (HTMLUNIT_DRIVER_CLASS.equals(type.getName())) {
+                capabilities = getCapabilities(
+                        extensionContext, parameter, Optional.empty(),
+                        Optional.empty());
+            }
 
             if (capabilities.isPresent()) {
                 driver = (WebDriver) type
                         .getDeclaredConstructor(Capabilities.class)
                         .newInstance(capabilities.get());
             } else {
-                driver = (WebDriver) type.getDeclaredConstructor()
+                driver = (WebDriver) Class.forName(HTMLUNIT_DRIVER_CLASS).getDeclaredConstructor()
                         .newInstance();
             }
         } catch (Exception e) {


### PR DESCRIPTION
### Purpose of changes
<!-- Please describe why this change is required / What problem you want to solve. -->
In the past I needed to change the signature of my unittest to be able to run it with HtmlUnit instead of with a slow browser. As HtmlUnitDriver implements WebDriver it seems logical to be able to use it as a pretend Selenium WebDriver when adding "-Dwdm.defaultBrowser=HTMLUNIT" to the command line.

```java
// use -Dwdm.defaultBrowser=HTMLUNIT to run with htmlunit instead of a slow browser
@ExtendWith(SeleniumJupiter.class)
class HelloServletIT {
	@Test
	void shouldEchoName(WebDriver driver) {
		String expected = "example;
		String actual = HelloServletPage.go(driver).submitName(expected);
		assertThat(actual, is(expected));
	}
}
```

### Types of changes
<!-- Put an `x` in the boxes that apply -->

- [ ] Bug-fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
I've run the unittests and they pass except for the chrome ones, but that is because I'm on linux.
I've run "mvn install" on this project then used it on my selenium project by replacing the dependency like this:
```xml
		<dependency>
			<groupId>io.github.bonigarcia</groupId>
			<artifactId>selenium-jupiter</artifactId>
			<version>5.1.1-SNAPSHOT</version>
			<scope>test</scope>
		</dependency>
```